### PR TITLE
Added Ewc json descriptors generation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,8 +270,15 @@ For both of these packages, a new version of Ext JS requires changing the versio
 * template.json
 
 
+## Generating JSON Descriptors for the Web Components.
+Gen It can be used to generate the JSON Descriptor file for each of the Ext Web Component which contains the information such as Properties, method and events etc about the Web Component. Follow the following steps -
 
+1) Generate the doxi JSON files as explained in first 3 steps at the start of this ReadMe file and place them in their respective folders.
+### 2 - Classic EWC Descriptors
+- run: npm run classic-ewc-jsondescriptors
 
+### 3 - Modern EWC Descriptors
+- run: npm run modern-ewc-jsondescriptors
 
 
 

--- a/README.md
+++ b/README.md
@@ -274,10 +274,11 @@ For both of these packages, a new version of Ext JS requires changing the versio
 Gen It can be used to generate the JSON Descriptor file for each of the Ext Web Component which contains the information such as Properties, method and events etc about the Web Component. Follow the following steps -
 
 1) Generate the doxi JSON files as explained in first 3 steps at the start of this ReadMe file and place them in their respective folders.
-### 2 - Classic EWC Descriptors
+
+2) - Classic EWC Descriptors
 - run: npm run classic-ewc-jsondescriptors
 
-### 3 - Modern EWC Descriptors
+3) - Modern EWC Descriptors
 - run: npm run modern-ewc-jsondescriptors
 
 

--- a/ewcJsonDescriptorsGenerator.js
+++ b/ewcJsonDescriptorsGenerator.js
@@ -1,0 +1,161 @@
+
+fs = require('fs');
+var path = require('path');
+
+const generateJSONDescriptorForElement = (doxiObj) => {
+	const widget = {
+		"name": doxiObj.name,
+		"selector": doxiObj.name.replace('.', '-').toLowerCase(),
+		"description": doxiObj.text
+	}
+
+	//Create Properties
+	const properties = [];
+	const events = [];
+	const methods = [];
+	let superClass = [];
+	if (doxiObj.extends) {
+		superClass = doxiObj.extends.split(',');
+	}
+	if (doxiObj.items) {
+		const doxiPropertiesItems = doxiObj.items.filter(item => item[`$type`] == 'properties');
+		if (doxiPropertiesItems.length > 0) {
+			const doxiProperties = doxiPropertiesItems[0].items;
+
+			doxiProperties.forEach(doxiProp => {
+
+				properties.push({
+					"name": doxiProp.name,
+					"type": doxiProp.type ? doxiProp.type.toLowerCase() : '',
+					"value": doxiProp.value,
+					"allowedValues": [],
+					"description": doxiProp.text,
+					"demoValues": []
+				})
+			})
+		}
+
+		//Using Configs
+		const doxiConfigItems = doxiObj.items.filter(item => item[`$type`] == 'configs');
+		if (doxiConfigItems.length > 0) {
+			const doxiProperties = doxiConfigItems[0].items.filter(x => x[`$type`] == "property");
+
+			doxiProperties.forEach(doxiProp => {
+
+				properties.push({
+					"name": doxiProp.name,
+					"type": doxiProp.type ? doxiProp.type.toLowerCase() : '',
+					"value": doxiProp.value,
+					"allowedValues": [],
+					"description": doxiProp.text,
+					"demoValues": []
+				})
+			})
+		}
+
+		//Create Events
+
+		const doxiEventsItems = doxiObj.items.filter(item => item[`$type`] == 'events');
+		if (doxiEventsItems.length > 0) {
+			const doxiEvents = doxiEventsItems[0].items;
+
+			doxiEvents.forEach(doxiEvent => {
+				const event = {
+					"name": doxiEvent.name,
+					"description": doxiEvent.text,
+					"demo": "events"
+				}
+				if (doxiEvent.items && doxiEvent.items.length > 0) {
+					event.detail = [];
+					doxiEvent.items.forEach(doxiEventParam => {
+						event.detail.push({
+							"name": doxiEventParam.name,
+							"description": doxiEventParam.text
+						})
+					})
+				}
+
+				events.push(event);
+			})
+		}
+
+		//create Methods
+
+		const doxiMethodsItems = doxiObj.items.filter(item => item[`$type`] == 'methods');
+		if (doxiMethodsItems.length > 0) {
+			const doxiMethods = doxiMethodsItems[0].items;
+
+			doxiMethods.forEach(doxiMethod => {
+				const method = {
+					"name": doxiMethod.name,
+					"description": doxiMethod.text ? doxiMethod.name : "",
+					"demoValues": [],
+					"returnDataType": null,
+					"demo": "methods"
+				}
+
+				if (doxiMethod.items && doxiMethod.items.length > 0) {
+					method.arguments = [];
+					const returnArgument = doxiMethod.items.filter(x => x['$type'] == 'return');
+					const params = doxiMethod.items.filter(x => x['$type'] != 'return');
+					if (returnArgument.length > 0) {
+						method.returnDataType = returnArgument[0].type;
+					}
+					params.forEach(param => {
+						method.arguments.push({
+							"name": param.name,
+							"type": param.type ? param.type : "",
+							"description": param.text ? param.text : "",
+							"optional": false
+						})
+					})
+				}
+
+				methods.push(method);
+			})
+		}
+	}
+
+	const jsonDescriptor = { superClass, widget, properties, events, methods };
+	//console.log(jsonDescriptor)
+	return jsonDescriptor;
+
+}
+
+const generateDescriptors = async (fileNameToProcess, outputFolder) => {
+	fs.readFile(fileNameToProcess, 'utf8', function (err, doxi) {
+		if (err) {
+			throw err;
+		}
+		const doxiJSON = doxi.toString();
+		const allElements = JSON.parse(doxiJSON);
+		const allDoxiElements = allElements.global.items.filter(x => x[`$type`] == 'class');
+		allDoxiElements.forEach(doxiObj => {
+			const json = generateJSONDescriptorForElement(doxiObj);
+			fs.writeFile(__dirname + `/${outputFolder}/${json.widget.name}.json`, JSON.stringify(json, null, 4), function (err, result) {
+				if (err) console.log('error', err);
+			});
+		})
+	})
+}
+
+const main = () => {
+	const extTheme = process.argv[2];
+	if (!extTheme) {
+		return console.error('Specify theme(modern or classic) as third argument.');
+	}
+	const outputFolder = `EWC_${extTheme}_Json_Descriptors`;
+	var outputDirPath = path.join(__dirname, outputFolder);
+
+	if (!fs.existsSync(outputDirPath)) {
+		fs.mkdirSync(outputDirPath);
+	}
+	const doxiPath = extTheme === 'classic' ? path.join(__dirname, 'AllClassesFiles', 'docs', 'classic', 'classic-all-classes-flatten.json') : path.join(__dirname, 'AllClassesFiles', 'docs', 'modern', 'modern-all-classes-flatten.json');
+	generateDescriptors(doxiPath, outputFolder).then(() => {
+		console.log('Job Completed.');
+	}).catch(e => {
+		console.error(e);
+	});
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -8,9 +8,12 @@
         "modern-extreact": "node ./genIt.js blank modern extreact",
         "classic-extwebcomponents": "node ./genIt.js blank classic extwebcomponents",
         "classic-extangular": "node ./genIt.js blank classic extangular",
-        "classic-extreact": "node ./genIt.js blank classic extreact"
+		"classic-extreact": "node ./genIt.js blank classic extreact",
+		"modern-json-descriptors" : "node ./json",
+        "modern-ewc-jsondescriptors": "node ./ewcJsonDescriptorsGenerator.js modern",
+        "classic-ewc-jsondescriptors": "node ./ewcJsonDescriptorsGenerator.js classic"
     },
-    "author": "Marc Gusmano",
+    "author": "Marc Gusmano",	
     "license": "MIT",
     "devDependencies": {
         "fs-copy-file-sync": "~1.1.1",


### PR DESCRIPTION

Following steps can be used to generate the Json descriptors -

Generate the doxi JSON files using SDK and copy them to ./AllClassesFiles/docs/classic/ and ./AllClassesFiles/docs/modern/ respectively.

For Classic EWC Descriptors
run: npm run classic-ewc-jsondescriptors

For Modern EWC Descriptors
run: npm run modern-ewc-jsondescriptors